### PR TITLE
R pipeline: Add membership fees & prep transaction data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ _targets*/*
 
 # For now, ignore this data file until 
 #   we download it from somewhere
-transaction-report*.csv
+memberclicks_transaction_report.csv
+institution_type_xwalk.csv

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ _targets*/*
 */tmp/*
 !*.placeholder
 
-# For now, ignore in/*
-# TODO: CHANGE!
-*/in/*
-!*/in/.placeholder
+# For now, ignore this data file until 
+#   we download it from somewhere
+transaction-report*.csv

--- a/01_fetch.R
+++ b/01_fetch.R
@@ -15,7 +15,15 @@ p1 <- list(
   tar_target(p1_membership_fees_csv, 
              '01_fetch/in/membership_fees.csv',
              format = 'file'),
-  tar_target(p1_membership_fees,  read_csv(p1_membership_fees_csv,
-                                           show_col_types = FALSE))
+  tar_target(p1_membership_fees, read_csv(p1_membership_fees_csv,
+                                          show_col_types = FALSE)),
+  
+  # Load the known institution type xwalk (not checking into Git history yet)
+  tar_target(p1_institution_type_xwalk_csv, 
+             'institution_type_xwalk.csv',
+             format = 'file'),
+  tar_target(p1_institution_type_xwalk, read_csv(p1_institution_type_xwalk_csv,
+                                                 col_types = list('memberclicks_id' = 'c'),
+                                                 show_col_types = FALSE))
   
 )

--- a/01_fetch.R
+++ b/01_fetch.R
@@ -4,11 +4,12 @@
 p1 <- list(
   
   # Load a recent transaction report manually exported from MemberClicks
-  tar_target(p1_transaction_report_csv, 
+  tar_target(p1_transaction_data_csv, 
              'transaction-report-09-23-2024.csv', 
              format='file'),
-  tar_target(p1_transaction_report, read_csv(p1_transaction_report_csv,
-                                             show_col_types = FALSE)),
+  tar_target(p1_transaction_data_raw, read_csv(p1_transaction_data_csv,
+                                               col_types = list('Profile ID' = 'c'),
+                                               show_col_types = FALSE)),
   
   # Load the known membership fees data
   tar_target(p1_membership_fees_csv, 

--- a/01_fetch.R
+++ b/01_fetch.R
@@ -5,7 +5,7 @@ p1 <- list(
   
   # Load a recent transaction report manually exported from MemberClicks
   tar_target(p1_transaction_data_csv, 
-             'transaction-report-09-23-2024.csv', 
+             'memberclicks_transaction_report.csv', 
              format='file'),
   tar_target(p1_transaction_data_raw, read_csv(p1_transaction_data_csv,
                                                col_types = list('Profile ID' = 'c'),

--- a/01_fetch.R
+++ b/01_fetch.R
@@ -4,7 +4,7 @@
 p1 <- list(
   
   tar_target(p1_transaction_report_csv, 
-             '01_fetch/in/transaction-report-09-23-2024.csv', 
+             'transaction-report-09-23-2024.csv', 
              format='file'),
   tar_target(p1_transaction_report, read_csv(p1_transaction_report_csv,
                                              show_col_types = FALSE))

--- a/01_fetch.R
+++ b/01_fetch.R
@@ -3,10 +3,18 @@
 
 p1 <- list(
   
+  # Load a recent transaction report manually exported from MemberClicks
   tar_target(p1_transaction_report_csv, 
              'transaction-report-09-23-2024.csv', 
              format='file'),
   tar_target(p1_transaction_report, read_csv(p1_transaction_report_csv,
-                                             show_col_types = FALSE))
+                                             show_col_types = FALSE)),
+  
+  # Load the known membership fees data
+  tar_target(p1_membership_fees_csv, 
+             '01_fetch/in/membership_fees.csv',
+             format = 'file'),
+  tar_target(p1_membership_fees,  read_csv(p1_membership_fees_csv,
+                                           show_col_types = FALSE))
   
 )

--- a/01_fetch/in/membership_fees.csv
+++ b/01_fetch/in/membership_fees.csv
@@ -1,7 +1,7 @@
-university_type,fee_type,start_date,end_date,amount
+institution_type,fee_type,start_date,end_date,amount
 University Member,annual,2016-01-01,2024-12-31,200
 University Member,initiation,2016-01-01,2024-12-31,2000
-Nonprofit Affiliate,annual,2016-01-01,2024-12-31,100
-Nonprofit Affiliate,initiation,2016-01-01,2024-12-31,500
+Non-profit Affiliate Member,annual,2016-01-01,2024-12-31,100
+Non-profit Affiliate Member,initiation,2016-01-01,2024-12-31,500
 Primarily Undergraduate Institution,annual,2016-01-01,2024-12-31,70
 Primarily Undergraduate Institution,initiation,2016-01-01,2024-12-31,700

--- a/01_fetch/in/membership_fees.csv
+++ b/01_fetch/in/membership_fees.csv
@@ -1,0 +1,7 @@
+university_type,fee_type,start_date,end_date,amount
+University Member,annual,2016-01-01,2024-12-31,200
+University Member,initiation,2016-01-01,2024-12-31,2000
+Nonprofit Affiliate,annual,2016-01-01,2024-12-31,100
+Nonprofit Affiliate,initiation,2016-01-01,2024-12-31,500
+Primarily Undergraduate Institution,annual,2016-01-01,2024-12-31,70
+Primarily Undergraduate Institution,initiation,2016-01-01,2024-12-31,700

--- a/02_clean.R
+++ b/02_clean.R
@@ -2,6 +2,11 @@
 # Handle eccentricities of the payment data - collapse multiple invoice rows 
 # into one, assign the correct payment type to each transaction
 
+# Load modular function files
+source('02_clean/src/prep_transaction_data.R')
+
 p2 <- list(
+  
+  tar_target(p2_transaction_data_ready, format_transaction_data_columns(p1_transaction_data_raw))
   
 )

--- a/02_clean.R
+++ b/02_clean.R
@@ -7,6 +7,7 @@ source('02_clean/src/prep_transaction_data.R')
 
 p2 <- list(
   
-  tar_target(p2_transaction_data_ready, format_transaction_data_columns(p1_transaction_data_raw))
+  tar_target(p2_transaction_data_ready, 
+             format_transaction_data(p1_transaction_data_raw, p1_institution_type_xwalk))
   
 )

--- a/02_clean/src/prep_transaction_data.R
+++ b/02_clean/src/prep_transaction_data.R
@@ -1,0 +1,14 @@
+
+
+format_transaction_data_columns <- function(transaction_data) {
+  transaction_data %>% 
+    rename(invoice_id = `Invoice ID`,
+           memberclicks_id = `Profile ID`) %>% 
+    mutate(date = as.Date(`Transaction Date`, format='%m/%d/%Y'),
+           payment_year = year(date),
+           amount = abs(Amount)) %>% 
+    select(payment_year, memberclicks_id, 
+           invoice_id, date, amount, details = Description) %>% 
+    arrange(payment_year, memberclicks_id, invoice_id, desc(amount))
+}
+

--- a/02_clean/src/prep_transaction_data.R
+++ b/02_clean/src/prep_transaction_data.R
@@ -1,14 +1,26 @@
 
 
-format_transaction_data_columns <- function(transaction_data) {
+format_transaction_data <- function(transaction_data, institution_type_xwalk) {
   transaction_data %>% 
     rename(invoice_id = `Invoice ID`,
            memberclicks_id = `Profile ID`) %>% 
     mutate(date = as.Date(`Transaction Date`, format='%m/%d/%Y'),
            payment_year = year(date),
-           amount = abs(Amount)) %>% 
-    select(payment_year, memberclicks_id, 
-           invoice_id, date, amount, details = Description) %>% 
-    arrange(payment_year, memberclicks_id, invoice_id, desc(amount))
+           # We know this is a charge to them, so make those positives (don't
+           # use absolute value just in case there is a refund included)
+           amount = Amount*-1) %>% 
+    # Add in the institution type information
+    left_join(institution_type_xwalk, by = "memberclicks_id") %>% 
+    # Sort data by year of the payment and institution, then invoice and amount
+    arrange(payment_year, memberclicks_id, invoice_id, desc(amount)) %>% 
+    # Keep only columns we need
+    select(payment_year, 
+           memberclicks_id, 
+           institution_nm, 
+           institution_type,
+           invoice_id, 
+           date, 
+           amount, 
+           details = Description)
 }
 

--- a/02_clean/src/prep_transaction_data.R
+++ b/02_clean/src/prep_transaction_data.R
@@ -1,5 +1,20 @@
 
-
+#' @title Format and prepare transaction columns used to identify membership status
+#' @description This function reformats and prepares columns in the raw transaction
+#' report output to prepare for determining fee types and eventually identify
+#' membership fee due dates.
+#' 
+#' @param transaction_data a tibble with the raw transaction report column from
+#' MemberClicks. Assumes the following columns are available: `Invoice ID`, 
+#' `Profile ID`, `Transaction Date`, `Amount`, and `Description`.
+#' @param institution_type_xwalk a table we put together to match institutions
+#' to an institution type. Currently matching using the MemberClicks ID provided
+#' per institution. Includes the columns `memberclicks_id`, `institution_nm`,
+#' and `institution_type`.
+#' 
+#' @returns a tibble with the columns `payment_year`, `memberclicks_id`, 
+#' `institution_nm`, `institution_type`, `invoice_id`, `date`, `amount`, and `details`.
+#' 
 format_transaction_data <- function(transaction_data, institution_type_xwalk) {
   transaction_data %>% 
     rename(invoice_id = `Invoice ID`,


### PR DESCRIPTION
This PR includes targets to load the membership fee table (`p1_membership_fees`)and prepare the transaction report raw data for further processing (`p2_transaction_data_ready`). To run this code, you will need the following files in your top-level R folder (future work will auto-download or gather the data in a more sophisticated process):

1. `memberclicks_transaction_report.csv` which is the raw transaction report data downloaded from MemberClicks. 
2. `institution_type_xwalk.csv` which is the institution crosswalk and includes the columns `memberclicks_id`, `institution_nm`, `institution_type`.

To run the pipeline, use the command `targets::tar_make()`. Then you can load the individual output targets with `targets::tar_load(p1_membership_fees)` and `targets::tar_load(p2_transaction_data_ready)`.

Current DAG generated with `targets::tar_visnetwork()`:

![image](https://github.com/user-attachments/assets/fc288f5b-3e25-46c1-82cc-4beca6275082)

Next step will be matching transactions to fee types (I already have some code started for this but trying to keep the PRs light and simple).